### PR TITLE
fix  failing script "bin/install_requirements.sh" on Windows

### DIFF
--- a/lesson/bin/install_requirements.sh
+++ b/lesson/bin/install_requirements.sh
@@ -2,6 +2,7 @@
 
 echo "Initialization: Installing requirements"
 python -V
+python -m ensurepip --default-pip
 python -m pip install --upgrade pip
 python -m pip freeze > requirements.txt
-# python -m pip install -r requirements.txt
+python -m pip install -r requirements.txt

--- a/lesson/bin/install_requirements.sh
+++ b/lesson/bin/install_requirements.sh
@@ -4,5 +4,5 @@ echo "Initialization: Installing requirements"
 python -V
 python -m ensurepip --default-pip
 python -m pip install --upgrade pip
-python -m pip freeze > requirements.txt
+tr -d '\r' < requirements.txt > requirements.txt
 python -m pip install -r requirements.txt

--- a/lesson/bin/install_requirements.sh
+++ b/lesson/bin/install_requirements.sh
@@ -3,4 +3,5 @@
 echo "Initialization: Installing requirements"
 python -V
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
+python -m pip freeze > requirements.txt
+# python -m pip install -r requirements.txt


### PR DESCRIPTION
**Issue:  ** #4
The bash script "bin/install_requirements.sh" is failing with the following error message:
```bash
bin/install_requirements.sh: line 2: $'\r': command not found
Initialization: Installing requirements
Unknown option: -
usage: python [option] ... [-c cmd | -m mod | file | -] [arg] ...
Try `python -h' for more information.
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt\r'
```


**Solution:**
The error message indicates that there is a problem with the format of the "requirements.txt" file. Specifically, the file has Windows-style line endings ("\r\n") instead of Unix-style line endings ("\n").

To fix this issue, we can create a new "requirements.txt" file with the correct line endings and copy the content of the other before the install by running the following command :
```bash
tr -d '\r' < requirements.txt > requirements.txt
```


This command will generate a new "requirements.txt" file with Unix-style line endings, which should resolve the issue.

**OS** : Windows 11
**Docker** : Docker version 20.10.17, build 100c701
**bash**: GNU bash, version 5.2.12(1)-release (x86_64-pc-msys)